### PR TITLE
Make /opt/jre32 and /opt/jre64 world-readable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,5 @@ RUN apt-get update \
     && echo "Installing Inno Setup binaries" \
     && wget -q -O is.exe "https://github.com/jrsoftware/issrc/releases/download/is-6_7_1/innosetup-6.7.1.exe" \
     && wine-x11-run wine is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES \
-    && chmod -R a+rX /root \
+    && chmod -R a+rX /root /opt/jre32 /opt/jre64 \
     && rm -rf is.exe /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- The Temurin 17.0.18 x64 JRE zip extracts `/opt/jre64` with mode `0770`, owned by `root:root`. Containers run as a non-root user (`-u $(id -u):$(id -g)`) cannot read it, breaking downstream installer builds (e.g. JSignPdf).
- Extend the existing `chmod -R a+rX /root` to also cover `/opt/jre32` and `/opt/jre64`.

## Test plan
- [ ] Rebuild image and verify `docker run --rm -u 1000:1000 kwart/innosetup ls /opt/jre64` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)